### PR TITLE
Add velo-scale instruction to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Modes of Operation:
 
   Mode changing in runtime is currently not supported, to avoid
   unwanted behaviour.
+  
+  Additionally, you'll need to set a velocity scaling factor in your hal:
+    
+    setp cia402.0.velo-scale 1000
 
 Homing:
 


### PR DESCRIPTION
Cheers for creating this, it has been immensely useful, but I spent ages trying to figure out how to get velocity mode working... turns out there's a velocity scale factor that wasn't obvious. Proposed change is just adding that info to the readme. 

Cheers